### PR TITLE
feat(core): implement Result<T> pattern and error types

### DIFF
--- a/Domain/Common/Error.cs
+++ b/Domain/Common/Error.cs
@@ -1,0 +1,19 @@
+namespace TelegramMediaRelayBot.Domain.Common;
+
+public sealed record Error(string Code, string Message, ErrorType Type)
+{
+    public static Error Validation(string code, string message) => new(code, message, ErrorType.Validation);
+    public static Error NotFound(string code, string message) => new(code, message, ErrorType.NotFound);
+    public static Error Conflict(string code, string message) => new(code, message, ErrorType.Conflict);
+    public static Error Infrastructure(string code, string message) => new(code, message, ErrorType.Infrastructure);
+    public static Error External(string code, string message) => new(code, message, ErrorType.External);
+}
+
+public enum ErrorType
+{
+    Validation,
+    NotFound,
+    Conflict,
+    Infrastructure,
+    External
+}

--- a/Domain/Common/Errors/DownloadErrors.cs
+++ b/Domain/Common/Errors/DownloadErrors.cs
@@ -1,0 +1,31 @@
+namespace TelegramMediaRelayBot.Domain.Common.Errors;
+
+public static class DownloadErrors
+{
+    public static Error UnsupportedUrl(string url) =>
+        Error.Validation("Download.UnsupportedUrl", $"URL is not supported: {url}");
+
+    public static Error NoFormatsFound(string url) =>
+        Error.External("Download.NoFormats", $"No downloadable formats found for: {url}");
+
+    public static Error Forbidden(string url) =>
+        Error.External("Download.Forbidden", $"Access denied (403) for: {url}");
+
+    public static Error RateLimited(string url) =>
+        Error.External("Download.RateLimited", $"Rate limited (429) for: {url}");
+
+    public static Error GeoBlocked(string url) =>
+        Error.External("Download.GeoBlocked", $"Content is geo-blocked: {url}");
+
+    public static Error AuthRequired(string url) =>
+        Error.External("Download.AuthRequired", $"Authentication required for: {url}");
+
+    public static Error Timeout(string url, TimeSpan duration) =>
+        Error.Infrastructure("Download.Timeout", $"Download timed out after {duration.TotalSeconds}s: {url}");
+
+    public static Error ProcessFailed(string message) =>
+        Error.Infrastructure("Download.ProcessFailed", message);
+
+    public static Error DiskFull() =>
+        Error.Infrastructure("Download.DiskFull", "Insufficient disk space for download");
+}

--- a/Domain/Common/Errors/ProxyErrors.cs
+++ b/Domain/Common/Errors/ProxyErrors.cs
@@ -1,0 +1,10 @@
+namespace TelegramMediaRelayBot.Domain.Common.Errors;
+
+public static class ProxyErrors
+{
+    public static Error ConnectionFailed(string proxyUrl) =>
+        Error.Infrastructure("Proxy.ConnectionFailed", $"Failed to connect through proxy: {proxyUrl}");
+
+    public static Error TorCircuitFailed() =>
+        Error.Infrastructure("Proxy.TorCircuitFailed", "Failed to request new Tor circuit");
+}

--- a/Domain/Common/Errors/TelegramErrors.cs
+++ b/Domain/Common/Errors/TelegramErrors.cs
@@ -1,0 +1,17 @@
+namespace TelegramMediaRelayBot.Domain.Common.Errors;
+
+public static class TelegramErrors
+{
+    public static Error FileTooLarge(long sizeBytes, long limitBytes) =>
+        Error.Validation("Telegram.FileTooLarge",
+            $"File size {sizeBytes / 1_048_576}MB exceeds limit {limitBytes / 1_048_576}MB");
+
+    public static Error ApiError(string message) =>
+        Error.External("Telegram.ApiError", message);
+
+    public static Error UserNotFound(long telegramId) =>
+        Error.NotFound("Telegram.UserNotFound", $"User not found: {telegramId}");
+
+    public static Error ChatNotFound(long chatId) =>
+        Error.NotFound("Telegram.ChatNotFound", $"Chat not found: {chatId}");
+}

--- a/Domain/Common/Result.cs
+++ b/Domain/Common/Result.cs
@@ -1,0 +1,42 @@
+namespace TelegramMediaRelayBot.Domain.Common;
+
+public sealed class Result<T>
+{
+    private Result(T? value, Error? error)
+    {
+        Value = value;
+        Error = error;
+    }
+
+    public T? Value { get; }
+    public Error? Error { get; }
+    public bool IsSuccess => Error is null;
+    public bool IsFailure => !IsSuccess;
+
+    public static Result<T> Success(T value) => new(value, null);
+    public static Result<T> Failure(Error error) => new(default, error);
+
+    public Result<TOut> Map<TOut>(Func<T, TOut> mapper)
+        => IsSuccess ? Result<TOut>.Success(mapper(Value!)) : Result<TOut>.Failure(Error!);
+
+    public async Task<Result<TOut>> MapAsync<TOut>(Func<T, Task<TOut>> mapper)
+        => IsSuccess ? Result<TOut>.Success(await mapper(Value!)) : Result<TOut>.Failure(Error!);
+
+    public Result<TOut> Bind<TOut>(Func<T, Result<TOut>> binder)
+        => IsSuccess ? binder(Value!) : Result<TOut>.Failure(Error!);
+
+    public async Task<Result<TOut>> BindAsync<TOut>(Func<T, Task<Result<TOut>>> binder)
+        => IsSuccess ? await binder(Value!) : Result<TOut>.Failure(Error!);
+
+    public TOut Match<TOut>(Func<T, TOut> onSuccess, Func<Error, TOut> onFailure)
+        => IsSuccess ? onSuccess(Value!) : onFailure(Error!);
+
+    public async Task<TOut> MatchAsync<TOut>(Func<T, Task<TOut>> onSuccess, Func<Error, Task<TOut>> onFailure)
+        => IsSuccess ? await onSuccess(Value!) : await onFailure(Error!);
+}
+
+public static class Result
+{
+    public static Result<T> Success<T>(T value) => Result<T>.Success(value);
+    public static Result<T> Failure<T>(Error error) => Result<T>.Failure(error);
+}


### PR DESCRIPTION
## Summary
- Adds `Result<T>` monad with `Map`, `Bind`, `Match` (sync + async)
- Adds `Error` record with typed factory methods (`Validation`, `NotFound`, `Conflict`, `Infrastructure`, `External`)
- Adds domain-specific error factories: `DownloadErrors`, `TelegramErrors`, `ProxyErrors`

Closes #2

## Files
- `Domain/Common/Result.cs` — generic Result type
- `Domain/Common/Error.cs` — Error record + ErrorType enum
- `Domain/Common/Errors/DownloadErrors.cs` — download-specific errors
- `Domain/Common/Errors/TelegramErrors.cs` — Telegram API errors
- `Domain/Common/Errors/ProxyErrors.cs` — proxy/Tor errors

## Test plan
- [ ] `dotnet build` passes
- [ ] New types are usable from other layers (will be integrated in subsequent phases)