### PR TITLE
feat(docker): add Docker support and self-hosted Telegram Bot API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+TELEGRAM_API_ID=your_api_id
+TELEGRAM_API_HASH=your_api_hash

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ TikTokMediaRelayBot.db
 hosts
 todo
 *.db
+.env
+data/

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -12,6 +12,7 @@
 using System.Resources;
 using Serilog.Events;
 using Microsoft.Extensions.Configuration;
+using Telegram.Bot;
 using TelegramMediaRelayBot.Database.Interfaces;
 
 
@@ -20,6 +21,8 @@ namespace TelegramMediaRelayBot
     class Config
     {
         public static string? telegramBotToken;
+        public static string? telegramApiBaseUrl;
+        public static string? telegramApiProxy;
         public static string sqlConnectionString;
         public static string databaseName = "TelegramMediaRelayBot";
         public static string dbType = "mysql";
@@ -64,6 +67,8 @@ namespace TelegramMediaRelayBot
                 .Build();
 
             telegramBotToken = configuration["AppSettings:TelegramBotToken"]!;
+            telegramApiBaseUrl = configuration["AppSettings:TelegramApiBaseUrl"];
+            telegramApiProxy = configuration["AppSettings:TelegramApiProxy"];
             sqlConnectionString = configuration["AppSettings:SqlConnectionString"]!;
             databaseName = configuration["AppSettings:DatabaseName"]!;
             language = configuration["AppSettings:Language"]!;
@@ -94,6 +99,34 @@ namespace TelegramMediaRelayBot
 
             whitelistedReferrerIds = configuration.GetSection("AccessPolicy:NewUsersPolicy:AllowRules:WhitelistedReferrerIds").Get<List<long>>() ?? new List<long>();
             blacklistedReferrerIds = configuration.GetSection("AccessPolicy:NewUsersPolicy:AllowRules:BlacklistedReferrerIds").Get<List<long>>() ?? new List<long>();
+        }
+
+        public static ITelegramBotClient CreateTelegramBotClient()
+        {
+            if (string.IsNullOrWhiteSpace(telegramBotToken))
+                throw new ArgumentException("Telegram Bot Token is not configured.");
+
+            HttpClient? httpClient = null;
+            if (!string.IsNullOrWhiteSpace(telegramApiProxy))
+            {
+                var proxy = new System.Net.WebProxy(telegramApiProxy);
+                var handler = new System.Net.Http.SocketsHttpHandler { Proxy = proxy, UseProxy = true };
+                httpClient = new HttpClient(handler);
+            }
+
+            TelegramBotClientOptions options;
+            if (!string.IsNullOrWhiteSpace(telegramApiBaseUrl))
+            {
+                options = new TelegramBotClientOptions(telegramBotToken, telegramApiBaseUrl);
+            }
+            else
+            {
+                options = new TelegramBotClientOptions(telegramBotToken);
+            }
+
+            return httpClient != null
+                ? new TelegramBotClient(options, httpClient)
+                : new TelegramBotClient(options);
         }
 
         public static string GetResourceString(string key)

--- a/Database/DBInit.cs
+++ b/Database/DBInit.cs
@@ -56,7 +56,7 @@ public class FluentDBMigrator
     {
         var builder = WebApplication.CreateBuilder(args);
         builder.Services.AddSingleton<ITelegramBotClient>(_ =>
-            new TelegramBotClient(Config.telegramBotToken!));
+            Config.CreateTelegramBotClient());
 
         builder.Services.AddSingleton<ILinkCategorizer>(_ =>
                     new HashTableLinkCategorizer(new DomainsLoader()));

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY *.csproj ./
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app --self-contained false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip ffmpeg && \
+    pip3 install --break-system-packages yt-dlp gallery-dl && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=build /app .
+ENTRYPOINT ["dotnet", "TelegramMediaRelayBot.dll"]

--- a/TelegramBot/MediaDownloader.cs
+++ b/TelegramBot/MediaDownloader.cs
@@ -63,8 +63,7 @@ public partial class TGBot
 
     public async Task Start()
     {
-        string telegramBotToken = Config.telegramBotToken!;
-        ITelegramBotClient _botClient = new TelegramBotClient(telegramBotToken);
+        ITelegramBotClient _botClient = Config.CreateTelegramBotClient();
 
         var me = await _botClient.GetMe();
         Log.Information($"Hello, I am {me.Id} ready and my name is {me.FirstName}.");

--- a/appsettings.json.example
+++ b/appsettings.json.example
@@ -8,7 +8,9 @@
         "Proxy": "socks5://127.0.0.1:9050",
         "UserUnMuteCheckInterval": 20,
         "UseGalleryDl": true,
-        "AccessDeniedMessageContact": ""
+        "AccessDeniedMessageContact": "",
+        "TelegramApiBaseUrl": null,
+        "TelegramApiProxy": null
     },
     "Tor": {
         "Enabled": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  bot:
+    build: .
+    restart: unless-stopped
+    volumes:
+      - ./data:/app/data
+      - ./appsettings.json:/app/appsettings.json:ro
+      - ./downloader-config.yaml:/app/downloader-config.yaml:ro
+    environment:
+      - AppSettings__TelegramApiBaseUrl=http://telegram-bot-api:8081
+    depends_on:
+      - telegram-bot-api
+    networks:
+      - bot-network
+
+  telegram-bot-api:
+    image: aiogram/telegram-bot-api:latest
+    restart: unless-stopped
+    environment:
+      TELEGRAM_API_ID: ${TELEGRAM_API_ID}
+      TELEGRAM_API_HASH: ${TELEGRAM_API_HASH}
+      TELEGRAM_LOCAL: "true"
+    volumes:
+      - ./data/telegram-bot-api:/var/lib/telegram-bot-api
+    ports:
+      - "8081:8081"
+    networks:
+      - bot-network
+
+networks:
+  bot-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Add `Dockerfile` (multi-stage: .NET 8 SDK → runtime + yt-dlp + gallery-dl + ffmpeg)
- Add `docker-compose.yml` with bot + `aiogram/telegram-bot-api` (local server, 2GB upload limit)
- Add `TelegramApiBaseUrl` config for self-hosted Bot API
- Add `TelegramApiProxy` config for SOCKS5/Tor proxy to Telegram API (critical for RU)
- Add `CreateTelegramBotClient()` factory method with proxy + custom base URL support

Closes #1

## Files
- `Dockerfile` — multi-stage build
- `docker-compose.yml` — bot + telegram-bot-api services
- `.env.example` — API_ID/API_HASH template
- `Config/Config.cs` — new fields + factory method
- `Database/DBInit.cs` — use factory method
- `TelegramBot/MediaDownloader.cs` — use factory method
- `appsettings.json.example` — new settings
- `.gitignore` — Docker artifacts

## Test plan
- [ ] `dotnet build` passes
- [ ] `docker-compose build` succeeds
- [ ] Bot connects to local Bot API when `TelegramApiBaseUrl` is set
- [ ] Bot connects through SOCKS5 proxy when `TelegramApiProxy` is set
- [ ] Without local API settings, bot works with cloud API as before