### PR TITLE
fix(sessions): add TTL and periodic cleanup to prevent memory leak

### DIFF
--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -32,6 +32,9 @@ namespace TelegramMediaRelayBot
         public static int videoGetDelay = 1000;
         public static int contactSendDelay = 1000;
 
+        public static int sessionTtlMinutes = 30;
+        public static int sessionCleanupIntervalMinutes = 5;
+
         public static LogEventLevel logLevel = LogEventLevel.Information;
         public static bool showVideoDownloadProgress = false;
         public static bool showVideoUploadProgress = false;
@@ -74,6 +77,9 @@ namespace TelegramMediaRelayBot
 
             videoGetDelay = configuration.GetValue("MessageDelaySettings:VideoGetDelay", 1000);
             contactSendDelay = configuration.GetValue("MessageDelaySettings:ContactSendDelay", 1000);
+
+            sessionTtlMinutes = configuration.GetValue("AppSettings:SessionTtlMinutes", 30);
+            sessionCleanupIntervalMinutes = configuration.GetValue("AppSettings:SessionCleanupIntervalMinutes", 5);
 
             logLevel = configuration.GetValue("ConsoleOutputSettings:LogLevel", LogEventLevel.Information);
             showVideoDownloadProgress = configuration.GetValue("ConsoleOutputSettings:ShowVideoDownloadProgress", false);

--- a/TelegramBot/Handlers/ICallBackQuery/IParameterizedCallBackQuery.cs
+++ b/TelegramBot/Handlers/ICallBackQuery/IParameterizedCallBackQuery.cs
@@ -133,13 +133,13 @@ public class SetVideoSendUsersCommand : IBotCallbackQueryHandlers
             if (action == UsersAction.SEND_MEDIA_TO_SPECIFIED_GROUPS) isGroup = true;
 
             Users.SetDefaultActionToUser(chatId, action, _defaultActionSetter, _userGetter);
-            TGBot.userStates[chatId] = new ProcessUserSetDCSendState(
+            UserSessionManager.Set(chatId, new ProcessUserSetDCSendState(
                 isGroup,
                 _contactGetterRepository,
                 _defaultAction,
                 _defaultActionGetter,
                 _userGetter,
-                _groupGetter);
+                _groupGetter));
             return;
         }
 
@@ -280,12 +280,12 @@ public class SetPrivacySiteFilterCommand : IBotCallbackQueryHandlers
             cancellationToken: ct
         );
 
-        TGBot.userStates[chatId] = new ProcessUserAddDomainFilterState(
+        UserSessionManager.Set(chatId, new ProcessUserAddDomainFilterState(
                 privacyRuleId,
                 _privacySettingsTargetsSetter,
                 userId,
                 false
-            );
+            ));
     }
 
     private async Task RemoveDomains(long chatId, int userId, Update update, ITelegramBotClient botClient, CancellationToken ct)
@@ -311,11 +311,11 @@ public class SetPrivacySiteFilterCommand : IBotCallbackQueryHandlers
             cancellationToken: ct
         );
 
-        TGBot.userStates[chatId] = new ProcessUserAddDomainFilterState(
+        UserSessionManager.Set(chatId, new ProcessUserAddDomainFilterState(
                 privacyRuleId,
                 _privacySettingsTargetsSetter,
                 userId,
                 true
-            );
+            ));
     }
 }

--- a/TelegramBot/Handlers/PrivateUpdateHandler.cs
+++ b/TelegramBot/Handlers/PrivateUpdateHandler.cs
@@ -83,7 +83,7 @@ public class PrivateUpdateHandler
             string defaultActionData = _defaultActionGetter.GetDefaultActionByUserIDAndType(userId, UsersActionTypes.DEFAULT_MEDIA_DISTRIBUTION);
 
             CancellationTokenSource timeoutCTS = new CancellationTokenSource();
-            TGBot.userStates[chatId] = new ProcessVideoDC(link, statusMessage, text, timeoutCTS, _tgBot, _contactGetterRepository, _userGetter, _groupGetter);
+            UserSessionManager.Set(chatId, new ProcessVideoDC(link, statusMessage, text, timeoutCTS, _tgBot, _contactGetterRepository, _userGetter, _groupGetter));
 
             if (defaultActionData == UsersAction.NO_VALUE) return;
 

--- a/TelegramBot/Handlers/Utils.cs
+++ b/TelegramBot/Handlers/Utils.cs
@@ -96,7 +96,7 @@ class PrivateUtils
                         break;
                 }
 
-                if (TGBot.userStates.TryGetValue(chatId, out var state) && state is ProcessVideoDC videoState)
+                if (UserSessionManager.TryGetValue(chatId, out var state) && state is ProcessVideoDC videoState)
                 {
                     await botClient.EditMessageText(
                         statusMessage.Chat.Id,
@@ -130,7 +130,7 @@ class PrivateUtils
                     }
                     else
                     {
-                        TGBot.userStates.Remove(chatId, out _);
+                        UserSessionManager.Remove(chatId, out _);
                     }
                 }
             }

--- a/TelegramBot/MediaDownloader.cs
+++ b/TelegramBot/MediaDownloader.cs
@@ -31,7 +31,7 @@ public partial class TGBot
     private readonly IPrivacySettingsGetter _privacySettingsGetter;
     private readonly ILinkCategorizer _categorizer;
     private readonly IUserFilterService _userFilter;
-    public static Dictionary<long, IUserState> userStates = [];
+    // User states are now managed by UserSessionManager
     public static CancellationToken cancellationToken;
 
     public TGBot(
@@ -89,7 +89,7 @@ public partial class TGBot
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (userStates[chatId] is IUserState userState)
+        if (UserSessionManager.Get(chatId) is IUserState userState)
         {
             await userState.ProcessState(botClient, update, cancellationToken);
         }
@@ -104,7 +104,7 @@ public partial class TGBot
 
         if (CommonUtilities.CheckPrivateChatType(update))
         {
-            if (userStates.ContainsKey(chatId))
+            if (UserSessionManager.ContainsKey(chatId))
             {
                 await ProcessState(botClient, update);
                 return;
@@ -346,7 +346,7 @@ public partial class TGBot
             return;
         }
 
-        if (userStates.TryGetValue(chatId, out IUserState? value))
+        if (UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             IUserState userState = value;
             currentUserStatus = userState.GetCurrentState();

--- a/TelegramBot/Menu/Contacts.cs
+++ b/TelegramBot/Menu/Contacts.cs
@@ -22,14 +22,14 @@ public class Contacts
 
     public static async Task AddContact(ITelegramBotClient botClient, Update update, long chatId, IContactAdder contactRepository, IContactGetter contactGetter, IUserGetter userGetter, IPrivacySettingsGetter privacySettingsGetter)
     {
-        TGBot.userStates[chatId] = new ProcessContactState(contactRepository, contactGetter, userGetter, privacySettingsGetter);
+        UserSessionManager.Set(chatId, new ProcessContactState(contactRepository, contactGetter, userGetter, privacySettingsGetter));
         await CommonUtilities.SendMessage(botClient, update, KeyboardUtils.GetReturnButtonMarkup(), cancellationToken, Config.GetResourceString("SpecifyContactLink"));
     }
 
     public static async Task DeleteContact(ITelegramBotClient botClient, Update update, long chatId, IContactRemover contactRemoverRepository, IContactGetter contactGetterRepository, IUserGetter userGetter)
     {
         Message statusMessage = await botClient.SendMessage(update.CallbackQuery!.Message!.Chat.Id, Config.GetResourceString("InputContactId"), cancellationToken: cancellationToken);
-        TGBot.userStates[chatId] = new ProcessRemoveUser(statusMessage, contactRemoverRepository, contactGetterRepository, userGetter);
+        UserSessionManager.Set(chatId, new ProcessRemoveUser(statusMessage, contactRemoverRepository, contactGetterRepository, userGetter));
     }
 
     public static async Task MuteUserContact(
@@ -41,7 +41,7 @@ public class Contacts
         IUserGetter userGetter)
     {
         await botClient.SendMessage(update.CallbackQuery!.Message!.Chat.Id, Config.GetResourceString("MuteUserInstructions"), cancellationToken: cancellationToken);
-        TGBot.userStates[chatId] = new ProcessUserMuteState(contactAdderRepository, contactGetterRepository, userGetter);
+        UserSessionManager.Set(chatId, new ProcessUserMuteState(contactAdderRepository, contactGetterRepository, userGetter));
     }
 
     public static async Task UnMuteUserContact(
@@ -53,7 +53,7 @@ public class Contacts
         IUserGetter userGetter)
     {
         await botClient.SendMessage(update.CallbackQuery!.Message!.Chat.Id, Config.GetResourceString("UnmuteUserInstructions"), cancellationToken: cancellationToken);
-        TGBot.userStates[chatId] = new ProcessUserUnMuteState(contactRemoverRepository, contactGetter, userGetter);
+        UserSessionManager.Set(chatId, new ProcessUserUnMuteState(contactRemoverRepository, contactGetter, userGetter));
     }
 
     public static async Task ViewContacts(ITelegramBotClient botClient, Update update, IContactGetter contactGetterRepository, IUserGetter userGetter)
@@ -81,7 +81,7 @@ public class Contacts
         IUserGetter userGetter,
         IGroupGetter groupGetter)
     {
-        TGBot.userStates[chatId] = new ProcessContactGroupState(contactGroupRepository, userGetter, groupGetter);
+        UserSessionManager.Set(chatId, new ProcessContactGroupState(contactGroupRepository, userGetter, groupGetter));
 
         int userId = userGetter.GetUserIDbyTelegramID(chatId);
         List<string> groupInfos = await UsersGroup.GetUserGroupInfoByUserId(userId, groupGetter);

--- a/TelegramBot/Menu/Groups.cs
+++ b/TelegramBot/Menu/Groups.cs
@@ -30,7 +30,7 @@ public class Groups
         long chatId = update.CallbackQuery!.Message!.Chat.Id;
         int userId = userGetter.GetUserIDbyTelegramID(chatId);
 
-        TGBot.userStates[chatId] = new ProcessUsersGroupState(userGetter, groupGetter, groupSetter);
+        UserSessionManager.Set(chatId, new ProcessUsersGroupState(userGetter, groupGetter, groupSetter));
         List<string> groupInfos = await UsersGroup.GetUserGroupInfoByUserId(userId, groupGetter);
 
         string messageText = groupInfos.Any() 

--- a/TelegramBot/Menu/Users.cs
+++ b/TelegramBot/Menu/Users.cs
@@ -176,7 +176,7 @@ public class UsersDB
         IUserGetter userGetter)
     {
         long chatId = CommonUtilities.GetIDfromUpdate(update);
-        TGBot.userStates[chatId] = new ProcessContactLinksState(false, contactRemoverRepository, contactGetterRepository, userRepository, userGetter);
+        UserSessionManager.Set(chatId, new ProcessContactLinksState(false, contactRemoverRepository, contactGetterRepository, userRepository, userGetter));
     }
 
     public static void UpdateSelfLinkWithDeleteSelectedContacts(Update update,
@@ -186,7 +186,7 @@ public class UsersDB
         IUserGetter userGetter)
     {
         long chatId = CommonUtilities.GetIDfromUpdate(update);
-        TGBot.userStates[chatId] = new ProcessContactLinksState(true, contactRemoverRepository, contactGetterRepository, userRepository, userGetter);
+        UserSessionManager.Set(chatId, new ProcessContactLinksState(true, contactRemoverRepository, contactGetterRepository, userRepository, userGetter));
     }
 
     public static bool UpdateSelfLinkWithContacts(Update update, IUserRepository userRepository, IUserGetter userGetter)

--- a/TelegramBot/Scheduler.cs
+++ b/TelegramBot/Scheduler.cs
@@ -35,6 +35,7 @@ class Scheduler
     {
         _unMuteTimer = new Timer(async _ => await CheckForUnmuteContacts(), null, TimeSpan.Zero, TimeSpan.FromSeconds(Config.userUnMuteCheckInterval));
         if (Config.torEnabled) _torChangingChainTimer = new Timer(async _ => await TorChangingChain(), null, TimeSpan.Zero, TimeSpan.FromMinutes(Config.torChangingChainInterval));
+        UserSessionManager.StartCleanupTimer();
         Log.Information("Scheduler started");
     }
 

--- a/TelegramBot/States/AcceptInboundInvite.cs
+++ b/TelegramBot/States/AcceptInboundInvite.cs
@@ -52,7 +52,7 @@ public class UserProcessInboundState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -70,14 +70,14 @@ public class UserProcessInboundState : IUserState
                     userState.currentState = UserInboundState.ProcessAction;
                     return;
                 }
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
                 break;
 
             case UserInboundState.ProcessAction:
                 if (update.Message != null && update.Message.Text != null)
                 {
-                    TGBot.userStates.Remove(chatId);
+                    UserSessionManager.Remove(chatId);
                     await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
                     return;
                 }
@@ -125,7 +125,7 @@ public class UserProcessInboundState : IUserState
                     userState.currentState = UserInboundState.ProcessAction;
                     return;
                 }
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
                 break;
         }

--- a/TelegramBot/States/AddContact.cs
+++ b/TelegramBot/States/AddContact.cs
@@ -63,7 +63,7 @@ public class ProcessContactState : IUserState
                 {
                     await ReplyKeyboardUtils.RemoveReplyMarkup(botClient, chatId, cancellationToken);
                     await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
-                    TGBot.userStates.Remove(chatId);
+                    UserSessionManager.Remove(chatId);
                     return;
                 }
 
@@ -131,7 +131,7 @@ public class ProcessContactState : IUserState
                 await ReplyKeyboardUtils.RemoveReplyMarkup(botClient, chatId, cancellationToken);
                 await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
 
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 break;
         }
     }

--- a/TelegramBot/States/ContactGroup.cs
+++ b/TelegramBot/States/ContactGroup.cs
@@ -55,7 +55,7 @@ public class ProcessContactGroupState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -134,7 +134,7 @@ public class ProcessContactGroupState : IUserState
                     ProcessFinish(chatId);
                     string text = !isDBActionSuccessful.Contains(false) ? Config.GetResourceString("SuccessActionResult") : Config.GetResourceString("ErrorActionResult");
                     await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken, text);
-                    TGBot.userStates.Remove(chatId);
+                    UserSessionManager.Remove(chatId);
                     return;
                 }
                 await botClient.SendMessage(chatId, Config.GetResourceString("InputErrorMessage"), cancellationToken: cancellationToken, replyMarkup: KeyboardUtils.GetReturnButtonMarkup());

--- a/TelegramBot/States/ContactLinks.cs
+++ b/TelegramBot/States/ContactLinks.cs
@@ -52,7 +52,7 @@ public class ProcessContactLinksState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value) || value is not ProcessContactLinksState userState)
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value) || value is not ProcessContactLinksState userState)
             return;
 
         switch (userState.currentState)
@@ -151,7 +151,7 @@ public class ProcessContactLinksState : IUserState
             actionStatus = _contactRemover.RemoveAllContactsExcept(userState.actingUserId, userState.targetIds);
         }
 
-        TGBot.userStates.Remove(chatId);
+        UserSessionManager.Remove(chatId);
 
         string statusMessage = actionStatus 
             ? Config.GetResourceString("SuccessActionResult") 
@@ -170,7 +170,7 @@ public class ProcessContactLinksState : IUserState
 
     private static async Task FinishState(ITelegramBotClient botClient, Update update, long chatId, CancellationToken cancellationToken)
     {
-        TGBot.userStates.Remove(chatId);
+        UserSessionManager.Remove(chatId);
         await CommonUtilities.SendMessage(
             botClient,
             update,

--- a/TelegramBot/States/DeleteContact.cs
+++ b/TelegramBot/States/DeleteContact.cs
@@ -92,7 +92,7 @@ public class ProcessRemoveUser : IUserState
                         string text = isDeleteSuccessful ? Config.GetResourceString("SuccessActionResult") : Config.GetResourceString("ErrorActionResult");
                         await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken, text);
                         
-                        TGBot.userStates.Remove(chatId);
+                        UserSessionManager.Remove(chatId);
                     }
                     else if (callbackData == "cancel_removal")
                     {

--- a/TelegramBot/States/Group.cs
+++ b/TelegramBot/States/Group.cs
@@ -55,7 +55,7 @@ public class ProcessUsersGroupState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -128,7 +128,7 @@ public class ProcessUsersGroupState : IUserState
                 await ProcessFinish(chatId);
                 string text = isDBActionSuccessful ? Config.GetResourceString("SuccessActionResult") : Config.GetResourceString("ErrorActionResult");
                 await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken, text);
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 break;
         }
     }

--- a/TelegramBot/States/MuteUser.cs
+++ b/TelegramBot/States/MuteUser.cs
@@ -53,7 +53,7 @@ public class ProcessUserMuteState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -140,7 +140,7 @@ public class ProcessUserMuteState : IUserState
                 if (await CommonUtilities.HandleStateBreakCommand(botClient, update, chatId)) return;
                 await ReplyKeyboardUtils.RemoveReplyMarkup(botClient, chatId, cancellationToken);
 
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 if (_contactAdder.AddMutedContact(mutedByUserId, mutedContactId, expirationDate))
                 {
                     await CommonUtilities.AlertMessageAndShowMenu(botClient, update, chatId, Config.GetResourceString("ActionCancelledError"));

--- a/TelegramBot/States/Outbound.cs
+++ b/TelegramBot/States/Outbound.cs
@@ -50,7 +50,7 @@ public class UserProcessOutboundState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -68,7 +68,7 @@ public class UserProcessOutboundState : IUserState
                     userState.currentState = UserOutboundState.Finish;
                     return;
                 }
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await CallbackQueryMenuUtils.ViewOutboundInviteLinks(botClient, update, _outboundDBGetter, _userGetter);
                 break;
 
@@ -77,7 +77,7 @@ public class UserProcessOutboundState : IUserState
                 {
                     if (update.CallbackQuery.Data!.StartsWith("user_show_outbound_invite:"))
                     {
-                        TGBot.userStates.Remove(chatId);
+                        UserSessionManager.Remove(chatId);
                         await CallbackQueryMenuUtils.ShowOutboundInvite(botClient, update, chatId, _contactRepository, _outboundDBGetter, _userGetter);
                         return;
                     }
@@ -88,7 +88,7 @@ public class UserProcessOutboundState : IUserState
                         _contactRepository.RemoveContactByStatus(_userGetter.GetUserIDbyTelegramID(chatId), accepterTelegramID, ContactsStatus.WAITING_FOR_ACCEPT);
                     }
                 }
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await ReplyKeyboardUtils.RemoveReplyMarkup(botClient, chatId, cancellationToken);
                 await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
                 break;

--- a/TelegramBot/States/UnMuteUser.cs
+++ b/TelegramBot/States/UnMuteUser.cs
@@ -52,7 +52,7 @@ public class ProcessUserUnMuteState : IUserState
         long chatId = CommonUtilities.GetIDfromUpdate(update);
         if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-        if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value))
+        if (!UserSessionManager.TryGetValue(chatId, out IUserState? value))
         {
             return;
         }
@@ -113,7 +113,7 @@ public class ProcessUserUnMuteState : IUserState
 
                 _contactRemover.RemoveMutedContact(mutedByUserId, mutedContactId);
                 await CommonUtilities.AlertMessageAndShowMenu(botClient, update, chatId, Config.GetResourceString("UserUnmuted"));
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 break;
         }
     }

--- a/TelegramBot/States/UserAddDomainFilter.cs
+++ b/TelegramBot/States/UserAddDomainFilter.cs
@@ -47,7 +47,7 @@ namespace TelegramMediaRelayBot
             long chatId = CommonUtilities.GetIDfromUpdate(update);
             if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-            if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value) || value is not ProcessUserAddDomainFilterState userState)
+            if (!UserSessionManager.TryGetValue(chatId, out IUserState? value) || value is not ProcessUserAddDomainFilterState userState)
                 return;
 
             switch (userState.currentState)
@@ -71,7 +71,7 @@ namespace TelegramMediaRelayBot
         {
             if (update.CallbackQuery != null)
             {
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await CommonUtilities.SendMessage(
                     botClient,
                     update,
@@ -131,7 +131,7 @@ namespace TelegramMediaRelayBot
             }
             else
             {
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await CommonUtilities.SendMessage(
                     botClient,
                     update,
@@ -157,7 +157,7 @@ namespace TelegramMediaRelayBot
                     await _privacySettingsTargetsSetter.SetToRemovePrivacyRuleTarget(_privacyRuleId, domain);
                 }
 
-            TGBot.userStates.Remove(chatId);
+            UserSessionManager.Remove(chatId);
             await CommonUtilities.SendMessage(
                 botClient,
                 update,

--- a/TelegramBot/States/UserDefaultSendContact.cs
+++ b/TelegramBot/States/UserDefaultSendContact.cs
@@ -54,7 +54,7 @@ namespace TelegramMediaRelayBot
             long chatId = CommonUtilities.GetIDfromUpdate(update);
             if (CommonUtilities.CheckNonZeroID(chatId)) return;
 
-            if (!TGBot.userStates.TryGetValue(chatId, out IUserState? value) || value is not ProcessUserSetDCSendState userState)
+            if (!UserSessionManager.TryGetValue(chatId, out IUserState? value) || value is not ProcessUserSetDCSendState userState)
                 return;
 
             switch (userState.currentState)
@@ -78,7 +78,7 @@ namespace TelegramMediaRelayBot
         {
             if (update.CallbackQuery != null)
             {
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await CommonUtilities.SendMessage(
                     botClient,
                     update,
@@ -145,7 +145,7 @@ namespace TelegramMediaRelayBot
             }
             else
             {
-                TGBot.userStates.Remove(chatId);
+                UserSessionManager.Remove(chatId);
                 await CommonUtilities.SendMessage(
                     botClient,
                     update,
@@ -183,7 +183,7 @@ namespace TelegramMediaRelayBot
                 }
             }
 
-            TGBot.userStates.Remove(chatId);
+            UserSessionManager.Remove(chatId);
             await CommonUtilities.SendMessage(
                 botClient,
                 update,

--- a/TelegramBot/States/VideoDistributionConfigurator.cs
+++ b/TelegramBot/States/VideoDistributionConfigurator.cs
@@ -72,7 +72,7 @@ public class ProcessVideoDC : IUserState
             case UsersStandardState.ProcessAction:
                 if (update.CallbackQuery != null)
                 {
-                    if (TGBot.userStates.TryGetValue(chatId, out var state) && state is ProcessVideoDC videoState)
+                    if (UserSessionManager.TryGetValue(chatId, out var state) && state is ProcessVideoDC videoState)
                     {
                         videoState.timeoutCTS.Cancel();
                     }
@@ -233,7 +233,7 @@ public class ProcessVideoDC : IUserState
                 }
                 else
                 {
-                    TGBot.userStates.Remove(chatId);
+                    UserSessionManager.Remove(chatId);
                 }
 
                 break;

--- a/TelegramBot/UserSessionManager.cs
+++ b/TelegramBot/UserSessionManager.cs
@@ -1,0 +1,101 @@
+// Copyright (C) 2024-2025 ZenonEl
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Эта программа является свободным программным обеспечением: вы можете распространять и/или изменять
+// её на условиях Стандартной общественной лицензии GNU Affero, опубликованной
+// Фондом свободного программного обеспечения, либо версии 3 лицензии, либо
+// (по вашему выбору) любой более поздней версии.
+
+
+using System.Collections.Concurrent;
+
+
+namespace TelegramMediaRelayBot;
+
+public static class UserSessionManager
+{
+    private static readonly ConcurrentDictionary<long, IUserState> _states = new();
+    private static readonly ConcurrentDictionary<long, DateTime> _createdAt = new();
+    private static Timer? _cleanupTimer;
+
+    public static void StartCleanupTimer()
+    {
+        _cleanupTimer = new Timer(
+            _ => CleanupExpiredSessions(),
+            null,
+            TimeSpan.FromMinutes(Config.sessionCleanupIntervalMinutes),
+            TimeSpan.FromMinutes(Config.sessionCleanupIntervalMinutes)
+        );
+        Log.Information("Session cleanup timer started (interval: {Interval} min, TTL: {TTL} min)",
+            Config.sessionCleanupIntervalMinutes, Config.sessionTtlMinutes);
+    }
+
+    public static IUserState? Get(long chatId)
+    {
+        _states.TryGetValue(chatId, out var state);
+        return state;
+    }
+
+    public static bool TryGetValue(long chatId, out IUserState? state)
+    {
+        return _states.TryGetValue(chatId, out state);
+    }
+
+    public static bool ContainsKey(long chatId)
+    {
+        return _states.ContainsKey(chatId);
+    }
+
+    public static void Set(long chatId, IUserState state)
+    {
+        _states[chatId] = state;
+        _createdAt[chatId] = DateTime.UtcNow;
+    }
+
+    public static bool Remove(long chatId)
+    {
+        _createdAt.TryRemove(chatId, out _);
+        return _states.TryRemove(chatId, out _);
+    }
+
+    public static bool Remove(long chatId, out IUserState? state)
+    {
+        _createdAt.TryRemove(chatId, out _);
+        return _states.TryRemove(chatId, out state);
+    }
+
+    private static void CleanupExpiredSessions()
+    {
+        var now = DateTime.UtcNow;
+        var ttl = TimeSpan.FromMinutes(Config.sessionTtlMinutes);
+        int cleaned = 0;
+
+        foreach (var kvp in _createdAt)
+        {
+            if (now - kvp.Value <= ttl) continue;
+
+            long chatId = kvp.Key;
+            if (_states.TryRemove(chatId, out var state))
+            {
+                if (state is ProcessVideoDC videoDc)
+                {
+                    try { videoDc.timeoutCTS.Cancel(); }
+                    catch (ObjectDisposedException) { }
+                }
+
+                _createdAt.TryRemove(chatId, out _);
+                cleaned++;
+                Log.Debug("Expired session removed for chat {ChatId}", chatId);
+            }
+        }
+
+        if (cleaned > 0)
+        {
+            Log.Information("Session cleanup: removed {Count} expired session(s), {Remaining} active",
+                cleaned, _states.Count);
+        }
+    }
+}

--- a/TelegramBot/Utils/CallbackQueryMenuUtils.cs
+++ b/TelegramBot/Utils/CallbackQueryMenuUtils.cs
@@ -39,7 +39,7 @@ public static class CallbackQueryMenuUtils
     {
         string text = Config.GetResourceString("YourInboundInvitations");
         await CommonUtilities.SendMessage(botClient, update, InBoundKB.GetInboundsKeyboardMarkup(update, inboundDBGetter, userGetter), cancellationToken, text);
-        TGBot.userStates[chatId] = new UserProcessInboundState(contactSetterRepository, contactRemoverRepository, inboundDBGetter, userGetter);
+        UserSessionManager.Set(chatId, new UserProcessInboundState(contactSetterRepository, contactRemoverRepository, inboundDBGetter, userGetter));
     }
 
     public static async Task ViewOutboundInviteLinks(ITelegramBotClient botClient, Update update, IOutboundDBGetter outboundDBGetter, IUserGetter userGetter)
@@ -58,7 +58,7 @@ public static class CallbackQueryMenuUtils
     {
         string userId = update.CallbackQuery!.Data!.Split(':')[1];
         await CommonUtilities.SendMessage(botClient, update, OutBoundKB.GetOutboundActionsKeyboardMarkup(userId), cancellationToken, Config.GetResourceString("OutboundInviteMenu"));
-        TGBot.userStates[chatId] = new UserProcessOutboundState(contactRepository, outboundDBGetter, userGetter);
+        UserSessionManager.Set(chatId, new UserProcessOutboundState(contactRepository, outboundDBGetter, userGetter));
     }
 
     public static Task AcceptInboundInvite(Update update, IContactSetter contactSetter)

--- a/TelegramBot/Utils/Utils.cs
+++ b/TelegramBot/Utils/Utils.cs
@@ -98,7 +98,7 @@ public static class CommonUtilities
     {
         await botClient.SendMessage(chatId, text, cancellationToken: cancellationToken);
         await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
-        TGBot.userStates.Remove(chatId);
+        UserSessionManager.Remove(chatId);
     }
 
     public static async Task<bool> HandleStateBreakCommand(ITelegramBotClient botClient,
@@ -113,7 +113,7 @@ public static class CommonUtilities
         {
             if (removeReplyMarkup) await ReplyKeyboardUtils.RemoveReplyMarkup(botClient, chatId, cancellationToken);
             await KeyboardUtils.SendInlineKeyboardMenu(botClient, update, cancellationToken);
-            TGBot.userStates.Remove(chatId);
+            UserSessionManager.Remove(chatId);
             return true;
         }
         return false;


### PR DESCRIPTION
## Summary
- Replace thread-unsafe `Dictionary<long, IUserState>` with thread-safe `ConcurrentDictionary`
- Extract session management from `TGBot` into dedicated `UserSessionManager` static class
- Add configurable TTL (default 30 min) and periodic cleanup (default 5 min interval)
- Cancel `CancellationTokenSource` on expired video download sessions
- Add `SessionTtlMinutes` and `SessionCleanupIntervalMinutes` config options

Closes #6

## Files
- New: `TelegramBot/UserSessionManager.cs` — thread-safe session management with TTL
- Modified: `Config/Config.cs` — new config fields
- Modified: `TelegramBot/Scheduler.cs` — starts cleanup timer
- Modified: 20 files in States/, Menu/, Handlers/, Utils/ — migrate from `TGBot.userStates` to `UserSessionManager`

## Test plan
- [ ] `dotnet build` passes (verified: 0 errors)
- [ ] Sessions are created and tracked on user interactions
- [ ] Abandoned sessions are cleaned up after TTL expires
- [ ] Active sessions are not prematurely cleaned
- [ ] Video download CTS is cancelled on session expiry