### PR TITLE
chore(dotnet): upgrade to .NET 9 and C# 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 COPY *.csproj ./
 RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /app --self-contained false
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip ffmpeg && \

--- a/TelegramMediaRelayBot.csproj
+++ b/TelegramMediaRelayBot.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>13</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>TelegramMediaRelayBot</AssemblyName>


### PR DESCRIPTION
## Summary
- Upgrade target framework from `net8.0` to `net9.0`
- Add `LangVersion 13` for C# 13 features
- Update Dockerfile base images to .NET 9

**Note:** `.github/workflows/main.yaml` needs manual update (`8.0.x` → `9.0.x`) — requires `workflow` scope token.

## Test plan
- [ ] `dotnet build` passes (verified: 0 errors)
- [ ] `docker build` succeeds with new base images
- [ ] CI passes after workflow update