### PR TITLE
feat(groups): implement media download in group chats

### DIFF
--- a/TelegramBot/Handlers/GroupUpdateHandler.cs
+++ b/TelegramBot/Handlers/GroupUpdateHandler.cs
@@ -15,7 +15,7 @@ namespace TelegramMediaRelayBot.TelegramBot.Handlers;
 
 public class GroupUpdateHandler
 {
-    private TGBot _tgBot;
+    private readonly TGBot _tgBot;
 
     public GroupUpdateHandler(
         TGBot tgBot)
@@ -26,39 +26,107 @@ public class GroupUpdateHandler
     public async Task HandleGroupUpdate(Update update, ITelegramBotClient botClient, CancellationToken cancellationToken)
     {
         string messageText = update.Message!.Text!;
-        if (messageText.Contains("/link"))
+        long chatId = update.Message.Chat.Id;
+
+        if (messageText.StartsWith("/link"))
         {
-            string link;
-            string text = "";
-
-            string trimmedMessage = messageText[5..].Trim();
-
-            int separatorIndex = trimmedMessage.IndexOfAny([' ', '\n']);
-
-            if (separatorIndex != -1)
-            {
-                link = trimmedMessage[..separatorIndex].Trim();
-                text = trimmedMessage[separatorIndex..].Trim();
-            }
-            else
-            {
-                link = trimmedMessage.Trim();
-            }
-
-            if (CommonUtilities.IsLink(link))
-            {
-                Message statusMessage = await botClient.SendMessage(update.Message.Chat.Id, Config.GetResourceString("WaitDownloadingVideo"), cancellationToken: cancellationToken);
-                _ = _tgBot.HandleMediaRequest(botClient, link, update.Message.Chat.Id, statusMessage: statusMessage, groupChat: true, caption: text);
-            }
-            else
-            {
-                await botClient.SendMessage(update.Message.Chat.Id, Config.GetResourceString("InvalidLinkFormat"), cancellationToken: cancellationToken);
-            }
+            await HandleLinkCommand(messageText, chatId, botClient, cancellationToken);
         }
         else if (messageText == "/help")
         {
             string text = Config.GetResourceString("GroupHelpText");
-            await botClient.SendMessage(update.Message.Chat.Id, text, cancellationToken: cancellationToken);
+            await botClient.SendMessage(chatId, text, cancellationToken: cancellationToken);
+        }
+        else
+        {
+            await HandlePlainUrl(messageText, chatId, update.Message.MessageId, botClient, cancellationToken);
+        }
+    }
+
+    private async Task HandleLinkCommand(string messageText, long chatId, ITelegramBotClient botClient, CancellationToken cancellationToken)
+    {
+        string link;
+        string caption = "";
+
+        string trimmedMessage = messageText[5..].Trim();
+
+        int separatorIndex = trimmedMessage.IndexOfAny([' ', '\n']);
+
+        if (separatorIndex != -1)
+        {
+            link = trimmedMessage[..separatorIndex].Trim();
+            caption = trimmedMessage[separatorIndex..].Trim();
+        }
+        else
+        {
+            link = trimmedMessage.Trim();
+        }
+
+        if (CommonUtilities.IsLink(link))
+        {
+            await DownloadAndSend(botClient, link, chatId, caption, cancellationToken);
+        }
+        else
+        {
+            await botClient.SendMessage(chatId, Config.GetResourceString("InvalidLinkFormat"), cancellationToken: cancellationToken);
+        }
+    }
+
+    private async Task HandlePlainUrl(string messageText, long chatId, int replyToMessageId, ITelegramBotClient botClient, CancellationToken cancellationToken)
+    {
+        string link;
+        string caption = "";
+
+        int newLineIndex = messageText.IndexOf('\n');
+
+        if (newLineIndex != -1)
+        {
+            link = messageText[..newLineIndex].Trim();
+            caption = messageText[(newLineIndex + 1)..].Trim();
+        }
+        else
+        {
+            link = messageText.Trim();
+        }
+
+        if (CommonUtilities.IsLink(link))
+        {
+            await DownloadAndSend(botClient, link, chatId, caption, cancellationToken);
+        }
+    }
+
+    private async Task DownloadAndSend(ITelegramBotClient botClient, string link, long chatId, string caption, CancellationToken cancellationToken)
+    {
+        Message statusMessage = await botClient.SendMessage(
+            chatId,
+            Config.GetResourceString("WaitDownloadingVideo"),
+            cancellationToken: cancellationToken
+        );
+
+        try
+        {
+            await _tgBot.HandleMediaRequest(botClient, link, chatId, statusMessage: statusMessage, groupChat: true, caption: caption);
+        }
+        catch (OperationCanceledException)
+        {
+            Log.Debug("Group media download was cancelled for chat {ChatId}", chatId);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to process media in group chat {ChatId}", chatId);
+            try
+            {
+                await botClient.EditMessageText(
+                    statusMessage.Chat.Id,
+                    statusMessage.MessageId,
+                    Config.GetResourceString("FailedToProcessLink"),
+                    cancellationToken: cancellationToken
+                );
+            }
+            catch (Exception editEx)
+            {
+                Log.Debug(editEx, "Failed to edit error status message");
+            }
         }
     }
 }

--- a/TelegramBot/MediaDownloader.cs
+++ b/TelegramBot/MediaDownloader.cs
@@ -139,9 +139,9 @@ public partial class TGBot
                 await _updateHandler.ProcessCallbackQuery(botClient, update, cancellationToken);
             }
         }
-        else 
+        else
         {
-            if (update.Message != null && update.Message.Text != null && update.Message.Text.Contains('/'))
+            if (update.Message != null && update.Message.Text != null)
             {
                 GroupUpdateHandler groupUpdateHandler = new GroupUpdateHandler(this);
                 await groupUpdateHandler.HandleGroupUpdate(update, botClient, cancellationToken);
@@ -332,7 +332,8 @@ public partial class TGBot
                 
                 if (!CommonUtilities.CheckPrivateChatType(update))
                 {
-                    if (!update.Message.Text.Contains("/link") && !update.Message.Text.Contains("/help")) return;
+                    if (!update.Message.Text.Contains("/link") && !update.Message.Text.Contains("/help")
+                        && !CommonUtilities.IsLink(update.Message.Text.Split('\n')[0].Trim())) return;
                 }
             }
             else


### PR DESCRIPTION
## Summary
- Implement URL auto-detection in group messages (same as private chats)
- Extract shared `DownloadAndSend()` for `/link` command and plain URL paths
- Replace fire-and-forget with proper await + error handling
- Handle cancellation and errors gracefully (edit status message)
- Allow all group text messages to reach handler (not just commands)

Closes #9

## Test plan
- [ ] `dotnet build` passes (verified)
- [ ] Send URL in group → bot downloads and sends media back
- [ ] `/link {url}` command works in groups
- [ ] URL with caption (newline separated) preserves caption
- [ ] Errors show message in group instead of crashing